### PR TITLE
Fix onunload recursion

### DIFF
--- a/src/codeblocks/BudgetCodeBlock.ts
+++ b/src/codeblocks/BudgetCodeBlock.ts
@@ -93,6 +93,7 @@ export class BudgetCodeBlock extends MarkdownRenderChild {
 
   public async onunload(): Promise<void> {
     await unmount(this.component);
-    super.unload();
+    // Call the base class cleanup without triggering a recursion
+    super.onunload();
   }
 }


### PR DESCRIPTION
## Summary
- avoid recursive unload in BudgetCodeBlock

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884feef9c4c8332b969e283566d3766