### PR TITLE
fix(table): handle long text and mobile layout issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ dist/
 
 # superpowers plans and specs (local work notes)
 docs/superpowers/
+.superpowers/
 

--- a/src/codeblocks/ui/componets/Table/CategoryFooter/CategoryFooter.svelte
+++ b/src/codeblocks/ui/componets/Table/CategoryFooter/CategoryFooter.svelte
@@ -70,6 +70,7 @@
 
     .label {
       font-size: calc(var(--font-smallest) - 5%);
+      white-space: nowrap;
     }
   }
 </style>

--- a/src/codeblocks/ui/componets/Table/CategoryFooter/CategoryFooter.svelte
+++ b/src/codeblocks/ui/componets/Table/CategoryFooter/CategoryFooter.svelte
@@ -66,6 +66,11 @@
       justify-items: end;
       gap: 0 0.5rem;
       padding: var(--size-2-2) var(--size-4-2);
+
+      @media (max-width: 480px) {
+        grid-template-columns: 1fr;
+        gap: 0;
+      }
     }
 
     .label {

--- a/src/codeblocks/ui/componets/Table/Editable/Editable.svelte
+++ b/src/codeblocks/ui/componets/Table/Editable/Editable.svelte
@@ -6,9 +6,10 @@
     value: string | number;
     onChange: (value: string | number) => void;
     onEditingChange: (isEditing: boolean) => void;
+    truncate?: boolean;
   };
 
-  let { value, onChange, onEditingChange }: Props = $props();
+  let { value, onChange, onEditingChange, truncate = false }: Props = $props();
 
   const valueType = $derived(typeof value === 'number' ? 'number' : 'text');
   const valueDisplay = $derived(
@@ -103,7 +104,11 @@
     onclick={handleOnClick}
     onkeydown={handleOnKeyDown}
   >
-    {valueDisplay}
+    {#if truncate}
+      <span class="truncated">{valueDisplay}</span>
+    {:else}
+      {valueDisplay}
+    {/if}
   </div>
 {/if}
 
@@ -147,9 +152,19 @@
     align-items: center;
     height: var(--input-height);
     cursor: text;
+    overflow: hidden;
+    min-width: 0;
   }
 
   .end {
     justify-content: end;
+  }
+
+  .truncated {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
   }
 </style>

--- a/src/codeblocks/ui/componets/Table/Editable/Editable.svelte
+++ b/src/codeblocks/ui/componets/Table/Editable/Editable.svelte
@@ -99,6 +99,7 @@
   <div
     class="text"
     class:end={valueType === 'number'}
+    class:truncating={truncate}
     role="button"
     tabindex="0"
     onclick={handleOnClick}
@@ -152,8 +153,11 @@
     align-items: center;
     height: var(--input-height);
     cursor: text;
-    overflow: hidden;
     min-width: 0;
+  }
+
+  .text.truncating {
+    overflow: hidden;
   }
 
   .end {

--- a/src/codeblocks/ui/componets/Table/Footer/Footer.svelte
+++ b/src/codeblocks/ui/componets/Table/Footer/Footer.svelte
@@ -63,6 +63,11 @@
     justify-items: end;
     gap: 0 0.5rem;
     padding: var(--size-2-2) var(--size-4-2);
+
+    @media (max-width: 480px) {
+      grid-template-columns: 1fr;
+      gap: 0;
+    }
   }
 
   .label {

--- a/src/codeblocks/ui/componets/Table/Footer/Footer.svelte
+++ b/src/codeblocks/ui/componets/Table/Footer/Footer.svelte
@@ -68,5 +68,6 @@
   .label {
     font-size: calc(var(--font-smallest) - 5%);
     font-weight: var(--font-normal);
+    white-space: nowrap;
   }
 </style>

--- a/src/codeblocks/ui/componets/Table/Head/Head.svelte
+++ b/src/codeblocks/ui/componets/Table/Head/Head.svelte
@@ -65,6 +65,8 @@
 
     th {
       padding: var(--size-2-2) var(--size-4-2);
+      white-space: nowrap;
+      overflow: hidden;
     }
   }
   .drag-handle-col {

--- a/src/codeblocks/ui/componets/Table/Head/Head.svelte
+++ b/src/codeblocks/ui/componets/Table/Head/Head.svelte
@@ -67,6 +67,7 @@
       padding: var(--size-2-2) var(--size-4-2);
       white-space: nowrap;
       overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
   .drag-handle-col {

--- a/src/codeblocks/ui/componets/Table/Row/Row.svelte
+++ b/src/codeblocks/ui/componets/Table/Row/Row.svelte
@@ -111,11 +111,12 @@
     </div>
   </td>
 
-  <td class="cell">
+  <td class="cell" title={row.name}>
     <Editable
       value={row.name}
       onChange={(value) => (name = String(value))}
       onEditingChange={toggleEditing}
+      truncate={true}
     />
   </td>
 
@@ -127,11 +128,12 @@
     />
   </td>
 
-  <td class="cell">
+  <td class="cell" title={row.comment}>
     <Editable
       value={row.comment}
       onChange={(value) => (comment = String(value))}
       onEditingChange={toggleEditing}
+      truncate={true}
     />
   </td>
 </tr>

--- a/src/codeblocks/ui/componets/Table/Table.svelte
+++ b/src/codeblocks/ui/componets/Table/Table.svelte
@@ -119,6 +119,7 @@
     border-spacing: 0;
     border-color: var(--table-border-color);
     border-width: var(--table-border-width);
+    table-layout: fixed;
   }
 
   :global(.sortable-ghost-row) {


### PR DESCRIPTION
## Summary

- Truncate long text in Name and Comment cells with `text-overflow: ellipsis`; full text shown via `title` tooltip on `<td>` hover
- Add `table-layout: fixed` to the table so percentage column widths are respected and truncation works correctly
- Prevent header (`Amount`) and footer labels (`SUM:`, `COUNT:`, `UNCHECKED:`) from wrapping on small screens
- Stack footer label and value vertically on screens ≤ 480px (e.g. `SUM:` / `1,505`) instead of breaking character-by-character

## Test Plan

- [x] Long text in Name and Comment cells is truncated with `...` — no line wrapping, rows stay single-line height
- [x] Hovering a truncated cell shows full text in native tooltip
- [x] Clicking a truncated cell enters edit mode with full text visible in input
- [x] Amount column is unchanged (numeric, right-aligned, no truncation)
- [x] Short text displays normally without `...`
- [x] On desktop: header labels and footer summary display on one line as before
- [x] On mobile (≤ 480px): `Amount` header stays on one line; `SUM:` / `COUNT:` labels appear above their values